### PR TITLE
[ImportVerilog] Adjust the order of test cases, which can correctly pass FileCheck.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,7 +390,7 @@ else()
 
     string(REGEX MATCH "Icarus Verilog version (([0-9]+)\.([0-9]+)) \.*"
       MATCH ${IVERILOG_VERSION})
-    
+
     if (${CMAKE_MATCH_1} LESS 11.0)
       message(FATAL_ERROR "CIRCT only supports Icarus Verilog version 11.0 and up. \
                            Found version: ${CMAKE_MATCH_1}. You can disable \
@@ -505,6 +505,43 @@ if(CIRCT_BINDINGS_TCL_ENABLED)
   message(STATUS "Found TCL include path: ${TCL_INCLUDE_PATH}")
   message(STATUS "Found TCL library: ${TCL_LIBRARY}")
   message(STATUS "Found TCL executable: ${TCL_TCLSH}")
+endif()
+
+#-------------------------------------------------------------------------------
+# slang Verilog Frontend
+#-------------------------------------------------------------------------------
+
+option(CIRCT_SLANG_FRONTEND_ENABLED "Enables slang Verilog frontend." ON)
+option(CIRCT_SLANG_BUILD_FROM_SOURCE
+  "Build slang from source instead of finding an installed package" ON)
+
+llvm_canonicalize_cmake_booleans(CIRCT_SLANG_FRONTEND_ENABLED)
+if(CIRCT_SLANG_FRONTEND_ENABLED)
+  message(STATUS "slang Verilog frontend is enabled")
+  if(CIRCT_SLANG_BUILD_FROM_SOURCE)
+    # Build slang as part of CIRCT (see https://sv-lang.com/building.html)
+    message(STATUS "Building slang from source")
+    set(original_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+    set(CMAKE_CXX_FLAGS "")
+    include(FetchContent)
+    FetchContent_Declare(
+      slang
+      GIT_REPOSITORY https://github.com/MikePopoloski/slang.git
+      GIT_TAG v2.0
+      GIT_SHALLOW ON)
+    FetchContent_MakeAvailable(slang)
+    # The following feels *very* hacky, but CMake complains about the
+    # CIRCTImportVerilog target linking against slang_slang (even with PRIVATE
+    # linking) without the latter being in an export set. I think we'd want to
+    # statically link slang into the CIRCTImportVerilog library, but seems to be
+    # harder than it ought to be.
+    set_property(GLOBAL APPEND PROPERTY CIRCT_EXPORTS slang_slang
+                                                      unordered_dense)
+    install(TARGETS slang_slang unordered_dense EXPORT CIRCTTargets)
+    set(CMAKE_CXX_FLAGS ${original_CXX_FLAGS})
+  else()
+    find_package(slang 2.0 REQUIRED)
+  endif()
 endif()
 
 #-------------------------------------------------------------------------------

--- a/include/circt/Conversion/ImportVerilog.h
+++ b/include/circt/Conversion/ImportVerilog.h
@@ -1,0 +1,39 @@
+//===- ImportVerilog.h - Slang Verilog frontend integration ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines the interface to the Verilog frontend.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_CONVERSION_IMPORTVERILOG_H
+#define CIRCT_CONVERSION_IMPORTVERILOG_H
+
+#include "circt/Support/LLVM.h"
+
+namespace llvm {
+class SourceMgr;
+} // namespace llvm
+
+namespace mlir {
+class LocationAttr;
+class TimingScope;
+} // namespace mlir
+
+namespace circt {
+
+/// Parse files in a source manager as Verilog source code.
+mlir::OwningOpRef<mlir::ModuleOp> importVerilog(llvm::SourceMgr &sourceMgr,
+                                                mlir::MLIRContext *context,
+                                                mlir::TimingScope &ts);
+
+/// Register the `import-verilog` MLIR translation.
+void registerFromVerilogTranslation();
+
+} // namespace circt
+
+#endif // CIRCT_CONVERSION_IMPORTVERILOG_H

--- a/include/circt/Dialect/Moore/Moore.td
+++ b/include/circt/Dialect/Moore/Moore.td
@@ -33,5 +33,6 @@ include "circt/Dialect/Moore/MooreTypesImpl.td"
 include "circt/Dialect/Moore/MooreTypes.td"
 include "circt/Dialect/Moore/MIRExpressions.td"
 include "circt/Dialect/Moore/MIRStatements.td"
+include "circt/Dialect/Moore/MooreOps.td"
 
 #endif // CIRCT_DIALECT_MOORE_MOORE

--- a/include/circt/Dialect/Moore/MooreOps.h
+++ b/include/circt/Dialect/Moore/MooreOps.h
@@ -1,4 +1,4 @@
-//===- MIROps.h - Declare Moore MIR dialect operations ----------*- C++ -*-===//
+//===- MooreOps.h - Declare Moore dialect operations ------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,12 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file declares the operation classes for the Moore MIR dialect.
+// This file declares the operation classes for the Moore dialect.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef CIRCT_DIALECT_MOORE_MIROPS_H
-#define CIRCT_DIALECT_MOORE_MIROPS_H
+#ifndef CIRCT_DIALECT_MOORE_MOOREOPS_H
+#define CIRCT_DIALECT_MOORE_MOOREOPS_H
 
 #include "circt/Dialect/Moore/MooreDialect.h"
 #include "circt/Dialect/Moore/MooreTypes.h"
@@ -22,4 +22,4 @@
 // Clang format shouldn't reorder these headers.
 #include "circt/Dialect/Moore/Moore.h.inc"
 
-#endif // CIRCT_DIALECT_MOORE_MIROPS_H
+#endif // CIRCT_DIALECT_MOORE_MOOREOPS_H

--- a/include/circt/Dialect/Moore/MooreOps.td
+++ b/include/circt/Dialect/Moore/MooreOps.td
@@ -1,0 +1,56 @@
+//===- MooreOps.td - Moore dialect operations --------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+include "mlir/IR/RegionKindInterface.td"
+include "circt/Dialect/Moore/MooreTypes.td"
+
+def SVModuleOp : MooreOp<"module", [
+  IsolatedFromAbove,
+  Symbol,
+  RegionKindInterface,
+  NoTerminator
+]> {
+  let summary = "A module definition";
+
+  let arguments = (ins SymbolNameAttr:$sym_name);
+  let regions = (region SizedRegion<1>:$body);
+  let assemblyFormat = [{
+    $sym_name attr-dict-with-keyword $body
+  }];
+
+  let extraClassDeclaration = [{
+    static mlir::RegionKind getRegionKind(unsigned index) {
+      return mlir::RegionKind::SSACFG;
+    }
+
+    mlir::Block &getBodyBlock() { return getBody().front(); }
+  }];
+}
+
+def InstanceOp : MooreOp<"instance", [
+  DeclareOpInterfaceMethods<SymbolUserOpInterface>
+]> {
+  let summary = "Create an instance of a module";
+
+  let arguments = (ins StrAttr:$instanceName,
+                       FlatSymbolRefAttr:$moduleName);
+  let assemblyFormat = [{
+    $instanceName $moduleName attr-dict
+  }];
+}
+
+def VariableOp : MooreOp<"variable", [
+  DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
+]> {
+  let summary = "Declare a variable";
+  let arguments = (ins StrAttr:$name);
+  let results = (outs UnpackedType:$result);
+  let assemblyFormat = [{
+    `` custom<ImplicitSSAName>($name) attr-dict `:` type($result)
+  }];
+}

--- a/include/circt/InitAllTranslations.h
+++ b/include/circt/InitAllTranslations.h
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "circt/Conversion/ImportVerilog.h"
 #include "circt/Dialect/Calyx/CalyxEmitter.h"
 #include "circt/Dialect/ESI/ESIDialect.h"
 #include "circt/Dialect/FIRRTL/FIREmitter.h"
@@ -33,6 +34,7 @@ inline void registerAllTranslations() {
     firrtl::registerFromFIRFileTranslation();
     firrtl::registerToFIRFileTranslation();
     ExportSystemC::registerExportSystemCTranslation();
+    registerFromVerilogTranslation();
     return true;
   }();
   (void)initOnce;

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -21,3 +21,7 @@ add_subdirectory(LoopScheduleToCalyx)
 add_subdirectory(StandardToHandshake)
 add_subdirectory(FSMToSV)
 add_subdirectory(PipelineToHW)
+
+if(CIRCT_SLANG_FRONTEND_ENABLED)
+  add_subdirectory(ImportVerilog)
+endif()

--- a/lib/Conversion/ImportVerilog/CMakeLists.txt
+++ b/lib/Conversion/ImportVerilog/CMakeLists.txt
@@ -1,0 +1,34 @@
+# slang uses exceptions
+set(LLVM_REQUIRES_EH ON)
+set(LLVM_REQUIRES_RTTI ON)
+
+# Disable some compiler warnings caused by slang headers such that the
+# `ImportVerilog` build doesn't spew out a ton of warnings that are not related
+# to CIRCT.
+if (MSVC)
+  # No idea what to put here
+else ()
+  # slang uses exceptions; we intercept these in ImportVerilog
+  add_compile_options(-fexceptions)
+  add_compile_options(-frtti)
+  # slang has some classes with virtual funcs but non-virtual destructor.
+  add_compile_options(-Wno-non-virtual-dtor)
+  # some other warnings we've seen
+  add_compile_options(-Wno-c++98-compat-extra-semi)
+  add_compile_options(-Wno-ctad-maybe-unsupported)
+  add_compile_options(-Wno-cast-qual)
+  # visitor switch statements cover all cases but have default
+  add_compile_options(-Wno-covered-switch-default)
+endif ()
+
+add_circt_translation_library(CIRCTImportVerilog
+  ImportVerilog.cpp
+  Structure.cpp
+  Types.cpp
+
+  LINK_LIBS PUBLIC
+  CIRCTMoore
+  MLIRTranslateLib
+  PRIVATE
+  slang::slang
+)

--- a/lib/Conversion/ImportVerilog/ImportVerilog.cpp
+++ b/lib/Conversion/ImportVerilog/ImportVerilog.cpp
@@ -1,0 +1,209 @@
+//===- ImportVerilog.cpp - Slang Verilog frontend integration -------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This implements bridging from the slang Verilog frontend to CIRCT dialects.
+//
+//===----------------------------------------------------------------------===//
+
+#include "ImportVerilogInternals.h"
+#include "circt/Dialect/Moore/MooreDialect.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Support/Timing.h"
+#include "mlir/Tools/mlir-translate/Translation.h"
+#include "slang/diagnostics/DiagnosticClient.h"
+#include "slang/driver/Driver.h"
+#include "llvm/ADT/Hashing.h"
+#include "llvm/Support/SourceMgr.h"
+
+using namespace circt;
+using namespace ImportVerilog;
+
+using llvm::SourceMgr;
+
+//===----------------------------------------------------------------------===//
+// Driver
+//===----------------------------------------------------------------------===//
+
+/// Convert a slang `SourceLocation` to an MLIR `Location`.
+Location ImportVerilog::convertLocation(
+    MLIRContext *context, const slang::SourceManager &sourceManager,
+    llvm::function_ref<StringRef(slang::BufferID)> getBufferFilePath,
+    slang::SourceLocation loc) {
+  if (loc && loc.buffer() != slang::SourceLocation::NoLocation.buffer()) {
+    auto fileName = getBufferFilePath(loc.buffer());
+    auto line = sourceManager.getLineNumber(loc);
+    auto column = sourceManager.getColumnNumber(loc);
+    return FileLineColLoc::get(context, fileName, line, column);
+  }
+  return UnknownLoc::get(context);
+}
+
+Location Context::convertLocation(slang::SourceLocation loc) {
+  return ImportVerilog::convertLocation(getContext(), sourceManager,
+                                        getBufferFilePath, loc);
+}
+
+namespace {
+/// A converter that can be plugged into a slang `DiagnosticEngine` as a client
+/// that will map slang diagnostics to their MLIR counterpart and emit them.
+class MlirDiagnosticClient : public slang::DiagnosticClient {
+public:
+  MlirDiagnosticClient(
+      MLIRContext *context,
+      std::function<StringRef(slang::BufferID)> getBufferFilePath)
+      : context(context), getBufferFilePath(getBufferFilePath) {}
+
+  void report(const slang::ReportedDiagnostic &diag) override {
+    // Generate the primary MLIR diagnostic.
+    auto &diagEngine = context->getDiagEngine();
+    auto mlirDiag = diagEngine.emit(convertLocation(diag.location),
+                                    getSeverity(diag.severity));
+    mlirDiag << diag.formattedMessage;
+
+    // Append the name of the option that can be used to control this
+    // diagnostic.
+    auto optionName = engine->getOptionName(diag.originalDiagnostic.code);
+    if (!optionName.empty())
+      mlirDiag << " [-W" << optionName << "]";
+
+    // Write out macro expansions, if we have any, in reverse order.
+    for (auto it = diag.expansionLocs.rbegin(); it != diag.expansionLocs.rend();
+         it++) {
+      auto &note = mlirDiag.attachNote(
+          convertLocation(sourceManager->getFullyOriginalLoc(*it)));
+      auto macro_name = sourceManager->getMacroName(*it);
+      if (macro_name.empty())
+        note << "expanded from here";
+      else
+        note << "expanded from macro '" << macro_name << "'";
+    }
+  }
+
+  /// Convert a slang `SourceLocation` to an MLIR `Location`.
+  Location convertLocation(slang::SourceLocation loc) const {
+    return ImportVerilog::convertLocation(context, *sourceManager,
+                                          getBufferFilePath, loc);
+  }
+
+  static mlir::DiagnosticSeverity
+  getSeverity(slang::DiagnosticSeverity severity) {
+    switch (severity) {
+    case slang::DiagnosticSeverity::Fatal:
+    case slang::DiagnosticSeverity::Error:
+      return mlir::DiagnosticSeverity::Error;
+    case slang::DiagnosticSeverity::Warning:
+      return mlir::DiagnosticSeverity::Warning;
+    case slang::DiagnosticSeverity::Ignored:
+    case slang::DiagnosticSeverity::Note:
+      return mlir::DiagnosticSeverity::Remark;
+    }
+    llvm_unreachable("all slang diagnostic severities should be handled");
+    return mlir::DiagnosticSeverity::Error;
+  }
+
+private:
+  MLIRContext *context;
+  std::function<StringRef(slang::BufferID)> getBufferFilePath;
+};
+} // namespace
+
+// Allow for slang::BufferID to be used as hash map keys.
+namespace llvm {
+template <>
+struct DenseMapInfo<slang::BufferID> {
+  static slang::BufferID getEmptyKey() { return slang::BufferID(); }
+  static slang::BufferID getTombstoneKey() {
+    return slang::BufferID(UINT32_MAX - 1, ""sv);
+    // UINT32_MAX is already used by `BufferID::getPlaceholder`.
+  }
+  static unsigned getHashValue(slang::BufferID id) {
+    return llvm::hash_value(id.getId());
+  }
+  static bool isEqual(slang::BufferID a, slang::BufferID b) { return a == b; }
+};
+} // namespace llvm
+
+// Parse the specified Verilog inputs into the specified MLIR context.
+mlir::OwningOpRef<mlir::ModuleOp> circt::importVerilog(SourceMgr &sourceMgr,
+                                                       MLIRContext *context,
+                                                       mlir::TimingScope &ts) {
+  // Use slang's driver which conveniently packages a lot of the things we need
+  // for compilation.
+  slang::driver::Driver driver;
+
+  // We keep a separate map from slang's buffers to the original MLIR file name
+  // since slang's `SourceLocation::getFileName` returns a modified version that
+  // is nice for human consumption (proximate paths, just file names, etc.), but
+  // breaks MLIR's assumption that the diagnostics report the exact file paths
+  // that appear in the `SourceMgr`. We use this separate map to lookup the
+  // exact paths and use those for reporting.
+  // See: https://github.com/MikePopoloski/slang/discussions/658
+  SmallDenseMap<slang::BufferID, StringRef> bufferFilePaths;
+  auto getBufferFilePath = [&](slang::BufferID id) {
+    return bufferFilePaths.lookup(id);
+  };
+
+  auto diagClient =
+      std::make_shared<MlirDiagnosticClient>(context, getBufferFilePath);
+  driver.diagEngine.addClient(diagClient);
+
+  // Populate the source manager with the source files.
+  // NOTE: This is a bit ugly since we're essentially copying the Verilog source
+  // text in memory. At a later stage we might want to extend slang's
+  // SourceManager such that it can contain non-owned buffers. This will do for
+  // now.
+  for (unsigned i = 0, e = sourceMgr.getNumBuffers(); i < e; ++i) {
+    const llvm::MemoryBuffer *mlirBuffer = sourceMgr.getMemoryBuffer(i + 1);
+    auto slangBuffer = driver.sourceManager.assignText(
+        mlirBuffer->getBufferIdentifier(), mlirBuffer->getBuffer());
+    driver.buffers.push_back(slangBuffer);
+    bufferFilePaths.insert({slangBuffer.id, mlirBuffer->getBufferIdentifier()});
+  }
+
+  // Parse the input.
+  auto parseTimer = ts.nest("Verilog parser");
+  bool parseSuccess = driver.parseAllSources();
+  parseTimer.stop();
+
+  // Elaborate the input.
+  auto compileTimer = ts.nest("Verilog elaboration");
+  auto compilation = driver.createCompilation();
+  for (auto &diag : compilation->getAllDiagnostics())
+    driver.diagEngine.issue(diag);
+  if (!parseSuccess || driver.diagEngine.getNumErrors() > 0)
+    return {};
+  compileTimer.stop();
+
+  // Traverse the parsed Verilog AST and map it to the equivalent CIRCT ops.
+  context->loadDialect<moore::MooreDialect>();
+  mlir::OwningOpRef<ModuleOp> module(
+      ModuleOp::create(UnknownLoc::get(context)));
+  auto conversionTimer = ts.nest("Verilog to dialect mapping");
+  Context ctx(module.get(), driver.sourceManager, getBufferFilePath,
+              *compilation);
+  if (failed(ctx.convertCompilation()))
+    return {};
+  conversionTimer.stop();
+
+  // Run the verifier on the constructed module to ensure it is clean.
+  auto verifierTimer = ts.nest("Post-parse verification");
+  if (failed(verify(*module)))
+    return {};
+  return module;
+}
+
+void circt::registerFromVerilogTranslation() {
+  static mlir::TranslateToMLIRRegistration fromVerilog(
+      "import-verilog", "import Verilog or SystemVerilog",
+      [](llvm::SourceMgr &sourceMgr, MLIRContext *context) {
+        mlir::TimingScope ts;
+        return importVerilog(sourceMgr, context, ts);
+      });
+}

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -1,0 +1,82 @@
+//===- ImportVerilogInternals.h - Internal implementation details ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CONVERSION_IMPORTVERILOG_IMPORTVERILOGINTERNALS_H
+#define CONVERSION_IMPORTVERILOG_IMPORTVERILOGINTERNALS_H
+
+#include "circt/Conversion/ImportVerilog.h"
+#include "circt/Dialect/Moore/MooreOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "slang/ast/Compilation.h"
+#include "slang/ast/Definition.h"
+#include "slang/syntax/SyntaxTree.h"
+#include "slang/syntax/SyntaxVisitor.h"
+#include "slang/text/SourceManager.h"
+#include "llvm/Support/Debug.h"
+#include <queue>
+
+#define DEBUG_TYPE "import-verilog"
+
+namespace circt {
+namespace ImportVerilog {
+
+struct Context {
+  Context(mlir::ModuleOp intoModuleOp,
+          const slang::SourceManager &sourceManager,
+          std::function<StringRef(slang::BufferID)> getBufferFilePath,
+          slang::ast::Compilation &compilation)
+      : intoModuleOp(intoModuleOp), sourceManager(sourceManager),
+        getBufferFilePath(getBufferFilePath), compilation(compilation),
+        rootBuilder(OpBuilder::atBlockEnd(intoModuleOp.getBody())),
+        symbolTable(intoModuleOp) {}
+  Context(const Context &) = delete;
+
+  /// Return the MLIR context.
+  MLIRContext *getContext() { return intoModuleOp.getContext(); }
+
+  /// Convert a slang `SourceLocation` into an MLIR `Location`.
+  Location convertLocation(slang::SourceLocation loc);
+
+  /// Convert a slang type into an MLIR type. Returns null on failure. Uses the
+  /// provided location for error reporting, or tries to guess one from the
+  /// given type. Types tend to have unreliable location information, so it's
+  /// generally a good idea to pass in a location.
+  Type convertType(const slang::ast::Type &type, LocationAttr loc = {});
+  Type convertType(const slang::ast::DeclaredType &type);
+
+  LogicalResult convertCompilation();
+  Operation *convertModuleHeader(const slang::ast::InstanceBodySymbol *module);
+  LogicalResult convertModuleBody(const slang::ast::InstanceBodySymbol *module);
+
+  mlir::ModuleOp intoModuleOp;
+  const slang::SourceManager &sourceManager;
+  std::function<StringRef(slang::BufferID)> getBufferFilePath;
+  slang::ast::Compilation &compilation;
+
+  /// A builder for modules and other top-level ops.
+  OpBuilder rootBuilder;
+  /// A symbol table of the MLIR module we are emitting into.
+  SymbolTable symbolTable;
+
+  /// How we have lowered modules to MLIR.
+  DenseMap<const slang::ast::InstanceBodySymbol *, Operation *> moduleOps;
+  /// A list of modules for which the header has been created, but the body has
+  /// not been converted yet.
+  std::queue<const slang::ast::InstanceBodySymbol *> moduleWorklist;
+};
+
+/// Convert a slang `SourceLocation` to an MLIR `Location`.
+Location convertLocation(
+    MLIRContext *context, const slang::SourceManager &sourceManager,
+    llvm::function_ref<StringRef(slang::BufferID)> getBufferFilePath,
+    slang::SourceLocation loc);
+
+} // namespace ImportVerilog
+} // namespace circt
+
+#endif // CONVERSION_IMPORTVERILOG_IMPORTVERILOGINTERNALS_H

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -116,6 +116,18 @@ Context::convertModuleBody(const slang::ast::InstanceBodySymbol *module) {
       continue;
     }
 
+    // Handle Nets.
+    if (member.kind == slang::ast::SymbolKind::Net) {
+      auto &netAst = member.as<slang::ast::NetSymbol>();
+      auto loweredType = convertType(*netAst.getDeclaredType());
+      if (!loweredType)
+        return failure();
+      builder.create<moore::VariableOp>(convertLocation(netAst.location),
+                                        loweredType,
+                                        builder.getStringAttr(netAst.name));
+      continue;
+    }
+
     mlir::emitError(loc, "unsupported module member: ")
         << slang::ast::toString(member.kind);
     return failure();

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -1,0 +1,125 @@
+//===- Structure.cpp - Slang hierarchy conversion -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ImportVerilogInternals.h"
+#include "slang/ast/ASTVisitor.h"
+#include "slang/ast/Symbol.h"
+#include "slang/ast/symbols/CompilationUnitSymbols.h"
+#include "slang/ast/symbols/InstanceSymbols.h"
+#include "slang/ast/symbols/VariableSymbols.h"
+#include "slang/ast/types/AllTypes.h"
+#include "slang/ast/types/Type.h"
+#include "slang/syntax/SyntaxVisitor.h"
+
+using namespace circt;
+using namespace ImportVerilog;
+
+LogicalResult Context::convertCompilation() {
+  auto &root = compilation.getRoot();
+
+  // Visit all the compilation units. This will mainly cover non-instantiable
+  // things like packages.
+  for (auto *unit : root.compilationUnits)
+    for (auto &member : unit->members())
+      LLVM_DEBUG(llvm::dbgs() << "Converting symbol " << member.name << "\n");
+
+  // Prime the root definition worklist by adding all the top-level modules to
+  // it.
+  for (auto *inst : root.topInstances)
+    convertModuleHeader(&inst->body);
+
+  // Convert all the root module definitions.
+  while (!moduleWorklist.empty()) {
+    auto module = moduleWorklist.front();
+    moduleWorklist.pop();
+    if (failed(convertModuleBody(module)))
+      return failure();
+  }
+
+  return success();
+}
+
+Operation *
+Context::convertModuleHeader(const slang::ast::InstanceBodySymbol *module) {
+  if (auto *op = moduleOps.lookup(module))
+    return op;
+  auto loc = convertLocation(module->location);
+
+  // We only support modules for now. Extension to interfaces and programs
+  // should be trivial though, since they are essentially the same thing with
+  // only minor differences in semantics.
+  if (module->getDefinition().definitionKind !=
+      slang::ast::DefinitionKind::Module) {
+    mlir::emitError(loc, "unsupported construct: ")
+        << module->getDefinition().getKindString();
+    return nullptr;
+  }
+
+  // Create an empty module that corresponds to this module.
+  auto moduleOp = rootBuilder.create<moore::SVModuleOp>(loc, module->name);
+  moduleOp.getBody().emplaceBlock();
+
+  // Add the module to the symbol table of the MLIR module, which uniquifies its
+  // name as we'd expect.
+  symbolTable.insert(moduleOp);
+
+  // Schedule the body to be lowered.
+  moduleWorklist.push(module);
+  moduleOps.insert({module, moduleOp});
+  return moduleOp;
+}
+
+LogicalResult
+Context::convertModuleBody(const slang::ast::InstanceBodySymbol *module) {
+  LLVM_DEBUG(llvm::dbgs() << "Converting body of module " << module->name
+                          << "\n");
+  auto moduleOp = moduleOps.lookup(module);
+  assert(moduleOp);
+  auto builder =
+      OpBuilder::atBlockEnd(&cast<moore::SVModuleOp>(moduleOp).getBodyBlock());
+
+  for (auto &member : module->members()) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "- Handling " << slang::ast::toString(member.kind) << "\n");
+    auto loc = convertLocation(member.location);
+
+    // Skip parameters.
+    if (member.kind == slang::ast::SymbolKind::Parameter)
+      continue;
+
+    // Handle instances.
+    if (member.kind == slang::ast::SymbolKind::Instance) {
+      auto &instAst = member.as<slang::ast::InstanceSymbol>();
+      auto targetModule = convertModuleHeader(&instAst.body);
+      if (!targetModule)
+        return failure();
+      builder.create<moore::InstanceOp>(
+          loc, builder.getStringAttr(instAst.name),
+          FlatSymbolRefAttr::get(SymbolTable::getSymbolName(targetModule)));
+      continue;
+    }
+
+    // Handle variables.
+    if (member.kind == slang::ast::SymbolKind::Variable) {
+      auto &varAst = member.as<slang::ast::VariableSymbol>();
+      auto loweredType = convertType(*varAst.getDeclaredType());
+      if (!loweredType)
+        return failure();
+      builder.create<moore::VariableOp>(convertLocation(varAst.location),
+                                        loweredType,
+                                        builder.getStringAttr(varAst.name));
+      continue;
+    }
+
+    mlir::emitError(loc, "unsupported module member: ")
+        << slang::ast::toString(member.kind);
+    return failure();
+  }
+
+  return success();
+}

--- a/lib/Conversion/ImportVerilog/Types.cpp
+++ b/lib/Conversion/ImportVerilog/Types.cpp
@@ -47,6 +47,23 @@ struct TypeVisitor {
     return moore::IntType::get(context.getContext(), kind, sign);
   }
 
+  Type visit(const slang::ast::FloatingType &type) {
+    moore::RealType::Kind kind;
+    switch (type.floatKind) {
+    case slang::ast::FloatingType::Real:
+      kind = moore::RealType::Real;
+      break;
+    case slang::ast::FloatingType::ShortReal:
+      kind = moore::RealType::ShortReal;
+      break;
+    case slang::ast::FloatingType::RealTime:
+      kind = moore::RealType::RealTime;
+      break;
+    }
+
+    return moore::RealType::get(context.getContext(), kind);
+  }
+
   Type visit(const slang::ast::PredefinedIntegerType &type) {
     moore::IntType::Kind kind;
     switch (type.integerKind) {

--- a/lib/Conversion/ImportVerilog/Types.cpp
+++ b/lib/Conversion/ImportVerilog/Types.cpp
@@ -109,6 +109,20 @@ struct TypeVisitor {
         packedInnerType, moore::Range(type.range.left, type.range.right));
   }
 
+  Type visit(const slang::ast::FixedSizeUnpackedArrayType &type) {
+    auto innerType = type.elementType.visit(*this);
+    if (!innerType)
+      return {};
+    auto unpackedInnerType = dyn_cast<moore::UnpackedType>(innerType);
+    if (!unpackedInnerType) {
+      mlir::emitError(loc, "dynamic unpacked array; ")
+          << type.elementType.toString() << " is fixed size unpacked";
+      return {};
+    }
+    return moore::UnpackedRangeDim::get(
+        unpackedInnerType, moore::Range(type.range.left, type.range.right));
+  }
+
   Type visit(const slang::ast::DynamicArrayType &type) {
     auto innerType = type.elementType.visit(*this);
     if (!innerType)
@@ -116,7 +130,7 @@ struct TypeVisitor {
     auto unpackedInnerType = dyn_cast<moore::UnpackedType>(innerType);
     if (!unpackedInnerType) {
       mlir::emitError(loc, "fixed size unpacked array; ")
-          << type.elementType.toString() << "is dynamic size unpacked";
+          << type.elementType.toString() << " is dynamic size unpacked";
       return {};
     }
     return moore::UnpackedUnsizedDim::get(unpackedInnerType);

--- a/lib/Conversion/ImportVerilog/Types.cpp
+++ b/lib/Conversion/ImportVerilog/Types.cpp
@@ -109,6 +109,19 @@ struct TypeVisitor {
         packedInnerType, moore::Range(type.range.left, type.range.right));
   }
 
+  Type visit(const slang::ast::DynamicArrayType &type) {
+    auto innerType = type.elementType.visit(*this);
+    if (!innerType)
+      return {};
+    auto unpackedInnerType = dyn_cast<moore::UnpackedType>(innerType);
+    if (!unpackedInnerType) {
+      mlir::emitError(loc, "fixed size unpacked array; ")
+          << type.elementType.toString() << "is dynamic size unpacked";
+      return {};
+    }
+    return moore::UnpackedUnsizedDim::get(unpackedInnerType);
+  }
+
   /// Emit an error for all other types.
   template <typename T>
   Type visit(T &&node) {

--- a/lib/Conversion/ImportVerilog/Types.cpp
+++ b/lib/Conversion/ImportVerilog/Types.cpp
@@ -47,6 +47,37 @@ struct TypeVisitor {
     return moore::IntType::get(context.getContext(), kind, sign);
   }
 
+  Type visit(const slang::ast::PredefinedIntegerType &type) {
+    moore::IntType::Kind kind;
+    switch (type.integerKind) {
+    case slang::ast::PredefinedIntegerType::Int:
+      kind = moore::IntType::Int;
+      break;
+    case slang::ast::PredefinedIntegerType::ShortInt:
+      kind = moore::IntType::ShortInt;
+      break;
+    case slang::ast::PredefinedIntegerType::LongInt:
+      kind = moore::IntType::LongInt;
+      break;
+    case slang::ast::PredefinedIntegerType::Integer:
+      kind = moore::IntType::Integer;
+      break;
+    case slang::ast::PredefinedIntegerType::Byte:
+      kind = moore::IntType::Byte;
+      break;
+    case slang::ast::PredefinedIntegerType::Time:
+      kind = moore::IntType::Time;
+      break;
+    }
+
+    std::optional<moore::Sign> sign =
+        type.isSigned ? moore::Sign::Signed : moore::Sign::Unsigned;
+    if (sign == moore::IntType::getDefaultSign(kind))
+      sign = {};
+
+    return moore::IntType::get(context.getContext(), kind, sign);
+  }
+
   Type visit(const slang::ast::PackedArrayType &type) {
     auto innerType = type.elementType.visit(*this);
     if (!innerType)

--- a/lib/Conversion/ImportVerilog/Types.cpp
+++ b/lib/Conversion/ImportVerilog/Types.cpp
@@ -109,6 +109,19 @@ struct TypeVisitor {
         packedInnerType, moore::Range(type.range.left, type.range.right));
   }
 
+  Type visit(const slang::ast::QueueType &type) {
+    auto innerType = type.elementType.visit(*this);
+    if (!innerType)
+      return {};
+    auto unpackedInnerType = dyn_cast<moore::UnpackedType>(innerType);
+    if (!unpackedInnerType) {
+      mlir::emitError(loc, "dynamic unpacked array; ")
+          << type.elementType.toString() << "is queue unpacked";
+      return {};
+    }
+    return moore::UnpackedQueueDim::get(unpackedInnerType, type.maxBound);
+  }
+
   Type visit(const slang::ast::AssociativeArrayType &type) {
     auto innerType = type.elementType.visit(*this);
     if (!innerType)

--- a/lib/Conversion/ImportVerilog/Types.cpp
+++ b/lib/Conversion/ImportVerilog/Types.cpp
@@ -1,0 +1,85 @@
+//===- Types.cpp - Slang type conversion ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ImportVerilogInternals.h"
+#include "slang/ast/ASTVisitor.h"
+#include "slang/ast/Symbol.h"
+#include "slang/ast/symbols/CompilationUnitSymbols.h"
+#include "slang/ast/symbols/InstanceSymbols.h"
+#include "slang/ast/symbols/VariableSymbols.h"
+#include "slang/ast/types/AllTypes.h"
+#include "slang/ast/types/Type.h"
+#include "slang/syntax/SyntaxVisitor.h"
+
+using namespace circt;
+using namespace ImportVerilog;
+
+namespace {
+struct TypeVisitor {
+  Context &context;
+  Location loc;
+  TypeVisitor(Context &context, Location loc) : context(context), loc(loc) {}
+
+  Type visit(const slang::ast::ScalarType &type) {
+    moore::IntType::Kind kind;
+    switch (type.scalarKind) {
+    case slang::ast::ScalarType::Bit:
+      kind = moore::IntType::Bit;
+      break;
+    case slang::ast::ScalarType::Logic:
+      kind = moore::IntType::Logic;
+      break;
+    case slang::ast::ScalarType::Reg:
+      kind = moore::IntType::Reg;
+      break;
+    }
+
+    std::optional<moore::Sign> sign =
+        type.isSigned ? moore::Sign::Signed : moore::Sign::Unsigned;
+    if (sign == moore::IntType::getDefaultSign(kind))
+      sign = {};
+
+    return moore::IntType::get(context.getContext(), kind, sign);
+  }
+
+  Type visit(const slang::ast::PackedArrayType &type) {
+    auto innerType = type.elementType.visit(*this);
+    if (!innerType)
+      return {};
+    auto packedInnerType = dyn_cast<moore::PackedType>(innerType);
+    if (!packedInnerType) {
+      mlir::emitError(loc, "packed array with unpacked elements; ")
+          << type.elementType.toString() << " is unpacked";
+      return {};
+    }
+    return moore::PackedRangeDim::get(
+        packedInnerType, moore::Range(type.range.left, type.range.right));
+  }
+
+  /// Emit an error for all other types.
+  template <typename T>
+  Type visit(T &&node) {
+    mlir::emitError(loc, "unsupported type: ")
+        << node.template as<slang::ast::Type>().toString();
+    return {};
+  }
+};
+} // namespace
+
+Type Context::convertType(const slang::ast::Type &type, LocationAttr loc) {
+  if (!loc)
+    loc = convertLocation(type.location);
+  return type.visit(TypeVisitor(*this, loc));
+}
+
+Type Context::convertType(const slang::ast::DeclaredType &type) {
+  LocationAttr loc;
+  if (auto *ts = type.getTypeSyntax())
+    loc = convertLocation(ts->sourceRange().start());
+  return convertType(type.getType(), loc);
+}

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -15,7 +15,7 @@
 #include "circt/Dialect/Comb/CombOps.h"
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/LLHD/IR/LLHDOps.h"
-#include "circt/Dialect/Moore/MIROps.h"
+#include "circt/Dialect/Moore/MooreOps.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinDialect.h"

--- a/lib/Dialect/Moore/CMakeLists.txt
+++ b/lib/Dialect/Moore/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_circt_dialect_library(CIRCTMoore
   MooreDialect.cpp
+  MooreOps.cpp
   MooreTypes.cpp
-  MIROps.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${CIRCT_MAIN_INCLUDE_DIR}/circt/Dialect/Moore
@@ -15,6 +15,7 @@ add_circt_dialect_library(CIRCTMoore
   Support
 
   LINK_LIBS PUBLIC
+  CIRCTSupport
   MLIRIR
   MLIRInferTypeOpInterface
 )

--- a/lib/Dialect/Moore/MooreDialect.cpp
+++ b/lib/Dialect/Moore/MooreDialect.cpp
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "circt/Dialect/Moore/MIROps.h"
+#include "circt/Dialect/Moore/MooreOps.h"
 
 using namespace circt;
 using namespace circt::moore;

--- a/lib/Dialect/Moore/MooreOps.cpp
+++ b/lib/Dialect/Moore/MooreOps.cpp
@@ -1,4 +1,4 @@
-//===- MIROps.cpp - Implement the Moore MIR operations --------------------===//
+//===- MooreOps.cpp - Implement the Moore operations ----------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,15 +6,43 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file implement the Moore MIR ops.
+// This file implements the Moore dialect operations.
 //
 //===----------------------------------------------------------------------===//
 
-#include "circt/Dialect/Moore/MIROps.h"
+#include "circt/Dialect/Moore/MooreOps.h"
+#include "circt/Support/CustomDirectiveImpl.h"
 #include "mlir/IR/Builders.h"
 
 using namespace circt;
 using namespace circt::moore;
+
+//===----------------------------------------------------------------------===//
+// InstanceOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult InstanceOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  auto *module =
+      symbolTable.lookupNearestSymbolFrom(*this, getModuleNameAttr());
+  if (module == nullptr)
+    return emitError("Cannot find module definition '")
+           << getModuleName() << "'";
+
+  // It must be some sort of module.
+  if (!isa<SVModuleOp>(module))
+    return emitError("symbol reference '")
+           << getModuleName() << "' isn't a module";
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// VariableOp
+//===----------------------------------------------------------------------===//
+
+void VariableOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  setNameFn(getResult(), getName());
+}
 
 //===----------------------------------------------------------------------===//
 // Type Inference

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -1,0 +1,40 @@
+// RUN: circt-translate --import-verilog %s | FileCheck %s
+
+// CHECK-LABEL: moore.module @Top1
+module Top1;
+    // CHECK-NEXT: moore.instance "child1" @Child
+    // CHECK-NEXT: moore.instance "child2" @Child_0
+    Child child1();
+    Child child2();
+endmodule
+
+// CHECK-LABEL: moore.module @Top2
+module Top2;
+endmodule
+
+// CHECK-LABEL: moore.module @Child
+// CHECK-NEXT:    moore.instance "p1" @Parametrized
+// CHECK-NEXT:    moore.instance "p2" @Parametrized_1
+// CHECK-LABEL: moore.module @Child_0
+// CHECK-NEXT:    moore.instance "p1" @Parametrized_2
+// CHECK-NEXT:    moore.instance "p2" @Parametrized_3
+module Child;
+    Parametrized #(42) p1();
+    Parametrized #(9001) p2();
+endmodule
+
+// CHECK-NOT: Bar
+package Bar;
+endpackage
+
+// CHECK-LABEL: moore.module @Parametrized
+// CHECK-NEXT:    %x = moore.variable : !moore.packed<range<logic, 41:0>>
+// CHECK-LABEL: moore.module @Parametrized_1
+// CHECK-NEXT:    %x = moore.variable : !moore.packed<range<logic, 9000:0>>
+// CHECK-LABEL: moore.module @Parametrized_2
+// CHECK-NEXT:    %x = moore.variable : !moore.packed<range<logic, 41:0>>
+// CHECK-LABEL: moore.module @Parametrized_3
+// CHECK-NEXT:    %x = moore.variable : !moore.packed<range<logic, 9000:0>>
+module Parametrized #(int N);
+    logic [N-1:0] x;
+endmodule

--- a/test/Conversion/ImportVerilog/errors.sv
+++ b/test/Conversion/ImportVerilog/errors.sv
@@ -1,0 +1,20 @@
+// RUN: circt-translate --import-verilog --verify-diagnostics --split-input-file %s
+
+// expected-error @below {{expected ';'}}
+module Foo 4;
+endmodule
+
+// expected-note @below {{expanded from macro 'FOO'}}
+`define FOO input
+// expected-note @below {{expanded from macro 'BAR'}}
+`define BAR `FOO
+// expected-error @below {{expected identifier}}
+module Bar(`BAR);
+endmodule
+
+// -----
+
+module Foo;
+  // expected-error @below {{unsupported module member}}
+  initial;
+endmodule

--- a/test/Conversion/ImportVerilog/types.sv
+++ b/test/Conversion/ImportVerilog/types.sv
@@ -5,23 +5,67 @@ module IntAtoms;
   // CHECK-NEXT: %d0 = moore.variable : !moore.logic
   // CHECK-NEXT: %d1 = moore.variable : !moore.bit
   // CHECK-NEXT: %d2 = moore.variable : !moore.reg
+  // CHECK-NEXT: %d3 = moore.variable : !moore.int
+  // CHECK-NEXT: %d4 = moore.variable : !moore.shortint
+  // CHECK-NEXT: %d5 = moore.variable : !moore.longint
+  // CHECK-NEXT: %d6 = moore.variable : !moore.integer
+  // CHECK-NEXT: %d7 = moore.variable : !moore.byte
+  // CHECK-NEXT: %d8 = moore.variable : !moore.time
   logic d0;
   bit d1;
   reg d2;
+  int d3;
+  shortint d4;
+  longint d5;
+  integer d6;
+  byte d7;
+  time d8;
 
   // CHECK-NEXT: %u0 = moore.variable : !moore.logic
   // CHECK-NEXT: %u1 = moore.variable : !moore.bit
   // CHECK-NEXT: %u2 = moore.variable : !moore.reg
+  // CHECK-NEXT: %u3 = moore.variable : !moore.int<unsigned>
+  // CHECK-NEXT: %u4 = moore.variable : !moore.shortint<unsigned>
+  // CHECK-NEXT: %u5 = moore.variable : !moore.longint<unsigned>
+  // CHECK-NEXT: %u6 = moore.variable : !moore.integer<unsigned>
+  // CHECK-NEXT: %u7 = moore.variable : !moore.byte<unsigned>
+  // CHECK-NEXT: %u8 = moore.variable : !moore.time
   logic unsigned u0;
   bit unsigned u1;
   reg unsigned u2;
+  int unsigned u3;
+  shortint unsigned u4;
+  longint unsigned u5;
+  integer unsigned u6;
+  byte unsigned u7;
+  time unsigned u8;
 
   // CHECK-NEXT: %s0 = moore.variable : !moore.logic<signed>
   // CHECK-NEXT: %s1 = moore.variable : !moore.bit<signed>
   // CHECK-NEXT: %s2 = moore.variable : !moore.reg<signed>
+  // CHECK-NEXT: %s3 = moore.variable : !moore.int
+  // CHECK-NEXT: %s4 = moore.variable : !moore.shortint
+  // CHECK-NEXT: %s5 = moore.variable : !moore.longint
+  // CHECK-NEXT: %s6 = moore.variable : !moore.integer
+  // CHECK-NEXT: %s7 = moore.variable : !moore.byte
+  // CHECK-NEXT: %s8 = moore.variable : !moore.time<signed>
   logic signed s0;
   bit signed s1;
   reg signed s2;
+  int signed s3;
+  shortint signed s4;
+  longint signed s5;
+  integer signed s6;
+  byte signed s7;
+  time signed s8;
+endmodule
+
+// CHECK-LABEL: moore.module @MultiPackedRangeDim
+module MultiPackedRangeDim;
+  // CHECK-NEXT: %v0 = moore.variable : !moore.packed<range<range<logic, 2:0>, 5:0>>
+  // CHECK-NEXT: %v1 = moore.variable : !moore.packed<range<range<logic, 2:0>, 5:0>>
+  logic [5:0][2:0] v0;
+  logic [0:5][2:0] v1;
 endmodule
 
 // CHECK-LABEL: moore.module @PackedRangeDim
@@ -32,10 +76,3 @@ module PackedRangeDim;
   logic [0:2] d1;
 endmodule
 
-// CHECK-LABEL: moore.module @MultiPackedRangeDim
-module MultiPackedRangeDim;
-  // CHECK-NEXT: %v0 = moore.variable : !moore.packed<range<range<logic, 2:0>, 5:0>>
-  // CHECK-NEXT: %v1 = moore.variable : !moore.packed<range<range<logic, 2:0>, 5:0>>
-  logic [5:0][2:0] v0;
-  logic [0:5][2:0] v1;
-endmodule

--- a/test/Conversion/ImportVerilog/types.sv
+++ b/test/Conversion/ImportVerilog/types.sv
@@ -68,6 +68,14 @@ module MultiPackedRangeDim;
   logic [0:5][2:0] v1;
 endmodule
 
+// CHECK-LABEL: moore.module @MultiPackedRangeDim
+module MultiPackedRangeDim;
+  // CHECK-NEXT: %v0 = moore.variable : !moore.packed<range<range<logic, 2:0>, 5:0>>
+  // CHECK-NEXT: %v1 = moore.variable : !moore.packed<range<range<logic, 2:0>, 0:5>>
+  logic [5:0][2:0] v0;
+  logic [0:5][2:0] v1;
+endmodule
+
 // CHECK-LABEL: moore.module @PackedRangeDim
 module PackedRangeDim;
   // CHECK-NEXT: %d0 = moore.variable : !moore.packed<range<logic, 2:0>>
@@ -76,3 +84,12 @@ module PackedRangeDim;
   logic [0:2] d1;
 endmodule
 
+// CHECK-LABEL: moore.module @RealType
+module RealType;
+  // CHECK-NEXT: %d0 = moore.variable : !moore.real
+  // CHECK-NEXT: %d1 = moore.variable : !moore.realtime
+  // CHECK-NEXT: %d2 = moore.variable : !moore.shortreal
+  real d0;
+  realtime d1;
+  shortreal d2;
+endmodule

--- a/test/Conversion/ImportVerilog/types.sv
+++ b/test/Conversion/ImportVerilog/types.sv
@@ -107,6 +107,22 @@ module MultiPackedRangeDim;
   logic [0:5][2:0] v1;
 endmodule
 
+// CHECK-LABEL: moore.module @MultiPackedRangeDim
+module MultiPackedRangeDim;
+  // CHECK-NEXT: %v0 = moore.variable : !moore.packed<range<range<logic, 2:0>, 5:0>>
+  // CHECK-NEXT: %v1 = moore.variable : !moore.packed<range<range<logic, 2:0>, 0:5>>
+  logic [5:0][2:0] v0;
+  logic [0:5][2:0] v1;
+endmodule
+
+// CHECK-LABEL: moore.module @NetType
+module NetType;
+  // CHECK-NEXT: %d0 = moore.variable : !moore.logic
+  // CHECK-NEXT: %d1 = moore.variable : !moore.logic
+  wire d0;
+  tri d1;
+endmodule;
+
 // CHECK-LABEL: moore.module @PackedRangeDim
 module PackedRangeDim;
   // CHECK-NEXT: %d0 = moore.variable : !moore.packed<range<logic, 2:0>>

--- a/test/Conversion/ImportVerilog/types.sv
+++ b/test/Conversion/ImportVerilog/types.sv
@@ -68,6 +68,14 @@ module MultiPackedRangeDim;
   logic [0:5][2:0] v1;
 endmodule
 
+// CHECK-LABEL: moore.module @MultiUnpackedRangeDim
+module MultiUnpackedRangeDim;
+  // CHECK-NEXT: %v0 = moore.variable : !moore.unpacked<range<range<logic, 2:0>, 5:0>>
+  // CHECK-NEXT: %v1 = moore.variable : !moore.unpacked<range<range<logic, 2:0>, 0:5>>
+  logic v0 [5:0][2:0];
+  logic v1 [0:5][2:0];
+endmodule
+  
 // CHECK-LABEL: moore.module @MultiUnpackedUnsizedDim
 module MultiUnpackedUnsizedDim;
   // CHECK-NEXT: %v0 = moore.variable : !moore.unpacked<unsized<unsized<logic>>>
@@ -91,6 +99,14 @@ module PackedRangeDim;
   logic [0:2] d1;
 endmodule
 
+// CHECK-LABEL: moore.module @UnpackedRangeDim
+module UnpackedRangeDim;
+  // CHECK-NEXT: %d0 = moore.variable : !moore.unpacked<range<logic, 2:0>>
+  // CHECK-NEXT: %d1 = moore.variable : !moore.unpacked<range<logic, 0:2>>
+  logic d0 [2:0];
+  logic d1 [0:2];
+endmodule
+  
 // CHECK-LABEL: moore.module @RealType
 module RealType;
   // CHECK-NEXT: %d0 = moore.variable : !moore.real

--- a/test/Conversion/ImportVerilog/types.sv
+++ b/test/Conversion/ImportVerilog/types.sv
@@ -91,6 +91,14 @@ module UnpackedUnsizedDim;
   logic [0:5][2:0] v1;
 endmodule
 
+// CHECK-LABEL: moore.module @MultiPackedRangeDim
+module MultiPackedRangeDim;
+  // CHECK-NEXT: %v0 = moore.variable : !moore.packed<range<range<logic, 2:0>, 5:0>>
+  // CHECK-NEXT: %v1 = moore.variable : !moore.packed<range<range<logic, 2:0>, 0:5>>
+  logic [5:0][2:0] v0;
+  logic [0:5][2:0] v1;
+endmodule
+
 // CHECK-LABEL: moore.module @PackedRangeDim
 module PackedRangeDim;
   // CHECK-NEXT: %d0 = moore.variable : !moore.packed<range<logic, 2:0>>
@@ -98,6 +106,14 @@ module PackedRangeDim;
   logic [2:0] d0;
   logic [0:2] d1;
 endmodule
+
+// CHECK-LABEL: moore.module @UnpackedAssocDim
+module UnpackedAssocDim;
+  // CHECK-NEXT: %d0 = moore.variable : !moore.unpacked<assoc<logic, int>>
+  // CEECK-NEXT: %d1 = moore.variable : !moore.unpacked<assoc<logic, logic>>
+  logic d0 [int];
+  logic d1 [logic];
+endmodule;
 
 // CHECK-LABEL: moore.module @UnpackedRangeDim
 module UnpackedRangeDim;

--- a/test/Conversion/ImportVerilog/types.sv
+++ b/test/Conversion/ImportVerilog/types.sv
@@ -63,15 +63,22 @@ endmodule
 // CHECK-LABEL: moore.module @MultiPackedRangeDim
 module MultiPackedRangeDim;
   // CHECK-NEXT: %v0 = moore.variable : !moore.packed<range<range<logic, 2:0>, 5:0>>
-  // CHECK-NEXT: %v1 = moore.variable : !moore.packed<range<range<logic, 2:0>, 5:0>>
+  // CHECK-NEXT: %v1 = moore.variable : !moore.packed<range<range<logic, 2:0>, 0:5>>
   logic [5:0][2:0] v0;
   logic [0:5][2:0] v1;
 endmodule
 
-// CHECK-LABEL: moore.module @MultiPackedRangeDim
-module MultiPackedRangeDim;
-  // CHECK-NEXT: %v0 = moore.variable : !moore.packed<range<range<logic, 2:0>, 5:0>>
-  // CHECK-NEXT: %v1 = moore.variable : !moore.packed<range<range<logic, 2:0>, 0:5>>
+// CHECK-LABEL: moore.module @MultiUnpackedUnsizedDim
+module MultiUnpackedUnsizedDim;
+  // CHECK-NEXT: %v0 = moore.variable : !moore.unpacked<unsized<unsized<logic>>>
+  logic v0 [][];
+endmodule
+
+// CHECK-LABEL: moore.module @UnpackedUnsizedDim
+module UnpackedUnsizedDim;
+  // CHECK-NEXT: %d0 = moore.variable : !moore.unpacked<unsized<logic>>
+  logic d0 [];
+  // CHECK-NEXT: %v1 = moore.variable : !moore.packed<range<range<logic, 2:0>, 5:0>>
   logic [5:0][2:0] v0;
   logic [0:5][2:0] v1;
 endmodule

--- a/test/Conversion/ImportVerilog/types.sv
+++ b/test/Conversion/ImportVerilog/types.sv
@@ -99,12 +99,28 @@ module MultiPackedRangeDim;
   logic [0:5][2:0] v1;
 endmodule
 
+// CHECK-LABEL: moore.module @MultiPackedRangeDim
+module MultiPackedRangeDim;
+  // CHECK-NEXT: %v0 = moore.variable : !moore.packed<range<range<logic, 2:0>, 5:0>>
+  // CHECK-NEXT: %v1 = moore.variable : !moore.packed<range<range<logic, 2:0>, 0:5>>
+  logic [5:0][2:0] v0;
+  logic [0:5][2:0] v1;
+endmodule
+
 // CHECK-LABEL: moore.module @PackedRangeDim
 module PackedRangeDim;
   // CHECK-NEXT: %d0 = moore.variable : !moore.packed<range<logic, 2:0>>
   // CHECK-NEXT: %d1 = moore.variable : !moore.packed<range<logic, 0:2>>
   logic [2:0] d0;
   logic [0:2] d1;
+endmodule
+
+// CHECK-LABEL: moore.module @UnpackedQueueDim
+module UnpackedQueueDim;
+  //CHECK-NEXT: %d0 = moore.variable : !moore.unpacked<queue<logic, 0>>
+  //CHECK-NEXT: %d1 = moore.variable : !moore.unpacked<queue<logic, 2>>
+  logic d0[$];
+  logic d1[$:2];
 endmodule
 
 // CHECK-LABEL: moore.module @UnpackedAssocDim

--- a/test/Conversion/ImportVerilog/types.sv
+++ b/test/Conversion/ImportVerilog/types.sv
@@ -1,0 +1,41 @@
+// RUN: circt-translate --import-verilog %s
+
+// CHECK-LABEL: moore.module @IntAtoms
+module IntAtoms;
+  // CHECK-NEXT: %d0 = moore.variable : !moore.logic
+  // CHECK-NEXT: %d1 = moore.variable : !moore.bit
+  // CHECK-NEXT: %d2 = moore.variable : !moore.reg
+  logic d0;
+  bit d1;
+  reg d2;
+
+  // CHECK-NEXT: %u0 = moore.variable : !moore.logic
+  // CHECK-NEXT: %u1 = moore.variable : !moore.bit
+  // CHECK-NEXT: %u2 = moore.variable : !moore.reg
+  logic unsigned u0;
+  bit unsigned u1;
+  reg unsigned u2;
+
+  // CHECK-NEXT: %s0 = moore.variable : !moore.logic<signed>
+  // CHECK-NEXT: %s1 = moore.variable : !moore.bit<signed>
+  // CHECK-NEXT: %s2 = moore.variable : !moore.reg<signed>
+  logic signed s0;
+  bit signed s1;
+  reg signed s2;
+endmodule
+
+// CHECK-LABEL: moore.module @PackedRangeDim
+module PackedRangeDim;
+  // CHECK-NEXT: %d0 = moore.variable : !moore.packed<range<logic, 2:0>>
+  // CHECK-NEXT: %d1 = moore.variable : !moore.packed<range<logic, 0:2>>
+  logic [2:0] d0;
+  logic [0:2] d1;
+endmodule
+
+// CHECK-LABEL: moore.module @MultiPackedRangeDim
+module MultiPackedRangeDim;
+  // CHECK-NEXT: %v0 = moore.variable : !moore.packed<range<range<logic, 2:0>, 5:0>>
+  // CHECK-NEXT: %v1 = moore.variable : !moore.packed<range<range<logic, 2:0>, 5:0>>
+  logic [5:0][2:0] v0;
+  logic [0:5][2:0] v1;
+endmodule


### PR DESCRIPTION
Hello, I viewed the test/Conversion/ImportVerilog/type.sv file under your slang-frontend branch. I found there are redundant, and the order is wrong. I think this mistake is because I created multiple PRs at a time. Therefore, I modify the file, and FileCheck can be passed correctly now.