### PR TITLE
[ImportVerilog] Support AddOp, MulOp and improved assignment Op

### DIFF
--- a/include/circt/Dialect/Moore/MIRExpressions.td
+++ b/include/circt/Dialect/Moore/MIRExpressions.td
@@ -12,6 +12,45 @@
 
 include "mlir/Interfaces/InferTypeOpInterface.td"
 
+// Base class for binary operators.
+class BinOp<string mnemonic, list<Trait> traits = []> :
+      MIROp<mnemonic, traits> {
+  let arguments = (ins AnyType:$lhs, AnyType:$rhs, UnitAttr:$twoState);
+  let results = (outs AnyType:$result);
+
+  let assemblyFormat =
+    "$lhs `,` $rhs (`bin` $twoState^)? attr-dict `:` functional-type($args, $results)";
+}
+
+// Binary operator with uniform input types.
+class UTBinOp<string mnemonic, list<Trait> traits = []> :
+      BinOp<mnemonic,
+               traits # [SameTypeOperands, SameOperandsAndResultType]> {
+  let assemblyFormat = "(`bin` $twoState^)? $lhs `,` $rhs attr-dict `:` qualified(type($result))";
+}
+
+// Base class for   variadic operators.
+class VariadicOp<string mnemonic, list<Trait> traits = []> :
+      MIROp<mnemonic, traits> {
+  let arguments = (ins Variadic<AnyType>:$inputs, UnitAttr:$twoState);
+  
+  let results = (outs AnyType:$result);
+}
+
+// VariadicOp with uniform input types.
+class UTVariadicOp<string mnemonic, list<Trait> traits = []> :
+      VariadicOp<mnemonic,
+                    traits # [SameTypeOperands, SameOperandsAndResultType]> {
+
+  let assemblyFormat = "(`bin` $twoState^)? $inputs attr-dict `:` qualified(type($result))";
+
+  let builders = [
+    OpBuilder<(ins "Value":$lhs, "Value":$rhs, CArg<"bool", "false">:$twoState), [{
+      return build($_builder, $_state, lhs.getType(),
+                   ValueRange{lhs, rhs}, twoState);
+    }]>
+  ];
+}
 
 def ConstantOp : MIROp<"constant", [Pure]> {
   let summary = "A constant value";
@@ -320,3 +359,12 @@ def BitwiseOp : MIROp<"binBitwise", [
     $bitwise $lhs `,` $rhs attr-dict `:` type($lhs) `,` type($rhs)
   }];
 }
+
+
+//===---------------------------------------------------------------------===//
+// Arithmetic Operations 
+//===---------------------------------------------------------------------===//
+
+// Arithmetic and Logical Operations.
+def AddOp : UTVariadicOp<"add", [Commutative]>;
+def MulOp : UTVariadicOp<"mul", [Commutative]>;

--- a/include/circt/Dialect/Moore/MIRStatements.td
+++ b/include/circt/Dialect/Moore/MIRStatements.td
@@ -87,3 +87,21 @@ def PAssignOp : MIROp<"passign",
     $dest `,` $src  attr-dict `:` qualified(type($src))
   }];
 }
+
+def PCAssignOp : MIROp<"pcassign",
+    [TypesMatchWith<"src and dest types have to match", "src", "dest",
+     "$_self">]> {
+
+  let summary = "Procedural continuous assignment";
+  let description = [{
+    A SystemVerilog assignment statement 'assign x = y;'.
+    The procedural continuous assignments (using keywords assign and force) are procedural statements
+    that allow expressions to be driven continuously onto variables or nets
+    These occur in procedural scope.  See SV Spec 10.6
+  }];
+  let arguments = (ins AnyType:$dest, AnyType:$src);
+  let results = (outs);
+  let assemblyFormat = [{
+    $dest `,` $src  attr-dict `:` qualified(type($src))
+  }];
+}

--- a/lib/Conversion/ImportVerilog/Expression.cpp
+++ b/lib/Conversion/ImportVerilog/Expression.cpp
@@ -198,6 +198,9 @@ Value Context::visitAssignmentExpr(
     if (assignmentExpr->syntax->parent->kind ==
         slang::syntax::SyntaxKind::ContinuousAssign)
       rootBuilder.create<moore::CAssignOp>(loc, lhs, rhs);
+    else if (assignmentExpr->syntax->parent->kind ==
+             slang::syntax::SyntaxKind::ProceduralAssignStatement)
+      rootBuilder.create<moore::PCAssignOp>(loc, lhs, rhs);
     else
       rootBuilder.create<moore::BPAssignOp>(loc, lhs, rhs);
   }

--- a/lib/Conversion/ImportVerilog/Expression.cpp
+++ b/lib/Conversion/ImportVerilog/Expression.cpp
@@ -91,14 +91,12 @@ Value Context::visitBinaryOp(const slang::ast::BinaryExpression *binaryExpr) {
 
   switch (binaryExpr->op) {
   case slang::ast::BinaryOperator::Add:
-    mlir::emitError(loc, "unsupported binary operator : add");
-    return nullptr;
+    return rootBuilder.create<moore::AddOp>(loc, lhs, rhs);
   case slang::ast::BinaryOperator::Subtract:
     mlir::emitError(loc, "unsupported binary operator : subtract");
     return nullptr;
   case slang::ast::BinaryOperator::Multiply:
-    mlir::emitError(loc, "unsupported binary operator : multiply");
-    return nullptr;
+    return rootBuilder.create<moore::MulOp>(loc, lhs, rhs);
   case slang::ast::BinaryOperator::Divide:
     mlir::emitError(loc, "unsupported binary operator : divide");
     return nullptr;

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -74,7 +74,6 @@ struct Context {
   visitAssignmentExpr(const slang::ast::AssignmentExpression *assignmentExpr);
   Value
   visitConcatenation(const slang::ast::ConcatenationExpression *concatExpr);
-  Value visitConversion(const slang::ast::ConversionExpression *conversionExpr);
 
   // Convert a slang timing control into an MLIR timing control.
   LogicalResult
@@ -102,12 +101,14 @@ struct Context {
   /// A symbol table of the MLIR module we are emitting into.
   SymbolTable symbolTable;
 
-  /// A symbol table of declared or defined variables. Like logic a = 1;
-  /// In varSymbolTable, the form is (a,a). Although there are two `a`
-  /// in the symbol table, the first type of a is StringRef,
-  /// and the second is Value created by the moore::VariableOp.
+  /// The symbol table maps a variable name to a value in the current scope,
+  /// which is declared or defined variables.
+  /// Entering a module creates a new scope, and the arguments are
+  /// added to the mapping. When the processing of a module is terminated, the
+  /// scope is destroyed and the mappings created in this scope are dropped.
   llvm::ScopedHashTable<StringRef, mlir::Value> varSymbolTable;
-
+  using SymbolTableScopeT =
+      llvm::ScopedHashTableScope<StringRef, mlir::Value>;
   /// How we have lowered modules to MLIR.
   DenseMap<const slang::ast::InstanceBodySymbol *, Operation *> moduleOps;
   /// A list of modules for which the header has been created, but the body has

--- a/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
+++ b/lib/Conversion/ImportVerilog/ImportVerilogInternals.h
@@ -107,8 +107,7 @@ struct Context {
   /// added to the mapping. When the processing of a module is terminated, the
   /// scope is destroyed and the mappings created in this scope are dropped.
   llvm::ScopedHashTable<StringRef, mlir::Value> varSymbolTable;
-  using SymbolTableScopeT =
-      llvm::ScopedHashTableScope<StringRef, mlir::Value>;
+  using SymbolTableScopeT = llvm::ScopedHashTableScope<StringRef, mlir::Value>;
   /// How we have lowered modules to MLIR.
   DenseMap<const slang::ast::InstanceBodySymbol *, Operation *> moduleOps;
   /// A list of modules for which the header has been created, but the body has

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -107,8 +107,9 @@ Context::convertModuleBody(const slang::ast::InstanceBodySymbol *module) {
   auto builder =
       OpBuilder::atBlockEnd(&cast<moore::SVModuleOp>(moduleOp).getBodyBlock());
 
-  // Create a new scope in a module. When the processing of a module is terminated, the
-  // scope is destroyed and the mappings created in this scope are dropped.
+  // Create a new scope in a module. When the processing of a module is
+  // terminated, the scope is destroyed and the mappings created in this scope
+  // are dropped.
   SymbolTableScopeT varScope(varSymbolTable);
 
   for (auto &member : module->members()) {

--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -15,6 +15,7 @@
 #include "slang/ast/types/AllTypes.h"
 #include "slang/ast/types/Type.h"
 #include "slang/syntax/SyntaxVisitor.h"
+#include "llvm/ADT/StringRef.h"
 
 using namespace circt;
 using namespace ImportVerilog;
@@ -106,7 +107,9 @@ Context::convertModuleBody(const slang::ast::InstanceBodySymbol *module) {
   auto builder =
       OpBuilder::atBlockEnd(&cast<moore::SVModuleOp>(moduleOp).getBodyBlock());
 
-  llvm::ScopedHashTableScope<StringRef, Value> scope(varSymbolTable);
+  // Create a new scope in a module. When the processing of a module is terminated, the
+  // scope is destroyed and the mappings created in this scope are dropped.
+  SymbolTableScopeT varScope(varSymbolTable);
 
   for (auto &member : module->members()) {
     LLVM_DEBUG(llvm::dbgs()

--- a/test/Conversion/ImportVerilog/arith.sv
+++ b/test/Conversion/ImportVerilog/arith.sv
@@ -1,0 +1,77 @@
+// RUN: circt-translate --import-verilog %s | FileCheck %s
+
+// CHECK-LABEL: moore.module @arith {
+module arith();
+    // CHECK-NEXT:  %a = moore.variable : !moore.int
+    // CHECK-NEXT:  %0 = moore.mir.constant 1 : !moore.int
+    // CHECK-NEXT:  moore.mir.bpassign %a, %0 : !moore.int
+    // CHECK-NEXT:  %b = moore.variable : !moore.int
+    // CHECK-NEXT:  %1 = moore.mir.constant 2 : !moore.int
+    // CHECK-NEXT:  moore.mir.bpassign %b, %1 : !moore.int
+int a=1;
+int b=2;
+initial begin
+    // CHECK-LABEL: moore.procedure(initial) {
+    // CHECK-NEXT:      %2 = moore.mir.constant 1 : !moore.int
+    // CHECK-NEXT:      %3 = moore.mir.constant 2 : !moore.int
+    // CHECK-NEXT:      %4 = moore.mir.add %2, %3 : !moore.int
+    // CHECK-NEXT:      moore.mir.bpassign %a, %4 : !moore.int
+    // CHECK-NEXT:      %5 = moore.mir.add %a, %b : !moore.int
+    // CHECK-NEXT:      moore.mir.bpassign %a, %5 : !moore.int
+    a=1+2;
+    a=a+b;
+    // CHECK-NEXT:      %6 = moore.mir.constant 1 : !moore.int
+    // CHECK-NEXT:      %7 = moore.mir.constant 2 : !moore.int
+    // CHECK-NEXT:      %8 = moore.mir.mul %6, %7 : !moore.int
+    // CHECK-NEXT:      moore.mir.bpassign %a, %8 : !moore.int
+    // CHECK-NEXT:      %9 = moore.mir.mul %a, %b : !moore.int
+    // CHECK-NEXT:      moore.mir.bpassign %a, %9 : !moore.int
+    a=1*2;
+    a=a*b;
+    // CHECK-NEXT:      %10 = moore.mir.constant 1 : !moore.int
+    // CHECK-NEXT:      %11 = moore.mir.add %10, %a : !moore.int
+    // CHECK-NEXT:      moore.mir.bpassign %a, %11 : !moore.int
+    // CHECK-NEXT:      %12 = moore.mir.constant 1 : !moore.int
+    // CHECK-NEXT:      %13 = moore.mir.mul %12, %a : !moore.int
+    // CHECK-NEXT:      moore.mir.bpassign %a, %13 : !moore.int
+    a=1+a;
+    a=1*a;
+    // CHECK-NEXT:      %14 = moore.mir.constant 1 : !moore.int
+    // CHECK-NEXT:      %15 = moore.mir.constant 2 : !moore.int
+    // CHECK-NEXT:      %16 = moore.mir.add %14, %15 : !moore.int
+    // CHECK-NEXT:      %17 = moore.mir.constant 3 : !moore.int
+    // CHECK-NEXT:      %18 = moore.mir.add %16, %17 : !moore.int
+    // CHECK-NEXT:      moore.mir.bpassign %a, %18 : !moore.int
+    a=1+2+3;
+    // CHECK-NEXT:      %19 = moore.mir.constant 1 : !moore.int
+    // CHECK-NEXT:      %20 = moore.mir.add %19, %a : !moore.int
+    // CHECK-NEXT:      %21 = moore.mir.constant 1 : !moore.int
+    // CHECK-NEXT:      %22 = moore.mir.add %20, %21 : !moore.int
+    // CHECK-NEXT:      moore.mir.bpassign %a, %22 : !moore.int
+    a=1+a+1;
+    // CHECK-NEXT:      %23 = moore.mir.add %a, %a : !moore.int
+    // CHECK-NEXT:      %24 = moore.mir.add %23, %a : !moore.int
+    // CHECK-NEXT:      moore.mir.bpassign %a, %24 : !moore.int
+    a=a+a+a;
+    // CHECK-NEXT:      %25 = moore.mir.constant 1 : !moore.int
+    // CHECK-NEXT:      %26 = moore.mir.constant 2 : !moore.int
+    // CHECK-NEXT:      %27 = moore.mir.mul %25, %26 : !moore.int
+    // CHECK-NEXT:      %28 = moore.mir.constant 3 : !moore.int
+    // CHECK-NEXT:      %29 = moore.mir.mul %27, %28 : !moore.int
+    // CHECK-NEXT:      moore.mir.bpassign %a, %29 : !moore.int
+    a=1*2*3;
+    // CHECK-NEXT:      %30 = moore.mir.constant 1 : !moore.int
+    // CHECK-NEXT:      %31 = moore.mir.mul %30, %a : !moore.int
+    // CHECK-NEXT:      %32 = moore.mir.constant 1 : !moore.int
+    // CHECK-NEXT:      %33 = moore.mir.mul %31, %32 : !moore.int
+    // CHECK-NEXT:      moore.mir.bpassign %a, %33 : !moore.int
+    a=1*a*1;
+    // CHECK-NEXT:      %34 = moore.mir.mul %a, %a : !moore.int
+    // CHECK-NEXT:      %35 = moore.mir.mul %34, %a : !moore.int
+    // CHECK-NEXT:      moore.mir.bpassign %a, %35 : !moore.int
+    a=a*a*a;
+    // CHECK-NEXT:        }
+    // CHECK-NEXT:      }
+    // CHECK-NEXT:    }
+end
+endmodule

--- a/test/Conversion/ImportVerilog/assign.sv
+++ b/test/Conversion/ImportVerilog/assign.sv
@@ -1,0 +1,65 @@
+// RUN: circt-translate --import-verilog %s | FileCheck %s
+
+// CHECK-LABEL: moore.module @bpassign {
+module bpassign();
+  // CHECK-NEXT: %bpassign_a = moore.variable : !moore.logic
+  // CHECK-NEXT: %bpassign_b = moore.variable : !moore.logic
+  // CHECK-NEXT: %0 = moore.mir.constant 2 : !moore.int
+  // CHECK-NEXT: %1 = moore.conversion %0 : (!moore.int) -> !moore.logic
+  // CHECK-NEXT: moore.mir.bpassign %bpassign_b, %1 : !moore.logic
+logic bpassign_a;
+logic bpassign_b = 2;
+
+// CHECK-LABEL: moore.procedure(initial) {
+initial begin
+  // CHECK-NEXT:    %2 = moore.mir.constant 1 : !moore.int
+  // CHECK-NEXT:    %3 = moore.conversion %2 : (!moore.int) -> !moore.logic
+  // CHECK-NEXT:    moore.mir.bpassign %bpassign_a, %3 : !moore.logic
+  // CHECK-NEXT:    moore.mir.bpassign %bpassign_b, %bpassign_a : !moore.logic
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+	bpassign_a = 1;
+	bpassign_b = bpassign_a;
+end
+endmodule
+
+// CHECK-LABEL: moore.module @cassign {
+module cassign();
+  // CHECK-NEXT:    %cassign_a = moore.variable : !moore.int
+  // CHECK-NEXT:    %0 = moore.mir.constant 2 : !moore.int
+  // CHECK-NEXT:    moore.mir.cassign %cassign_a, %0 : !moore.int
+  // CHECK-NEXT:  }
+int cassign_a;
+assign cassign_a = 2;
+endmodule
+
+// CHECK-LABEL: moore.module @passign {
+module passign();
+  // CHECK-NEXT:    %passign_a = moore.variable : !moore.logic
+  // CHECK-LABEL:   moore.procedure(initial) {
+  // CHECK-NEXT:      %0 = moore.mir.constant 2 : !moore.int
+  // CHECK-NEXT:      %1 = moore.conversion %0 : (!moore.int) -> !moore.logic
+  // CHECK-NEXT:      moore.mir.passign %passign_a, %1 : !moore.logic
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+  logic passign_a;
+initial begin
+	passign_a <= 2;
+end
+endmodule
+
+
+// CHECK-LABEL: moore.module @pcassign {
+module pcassign();
+  // CHECK-NEXT:  %pcassign = moore.variable : !moore.int
+  // CHECK-LABEL: moore.procedure(initial) {
+  // CHECK-NEXT:    %0 = moore.mir.constant 2 : !moore.int
+  // CHECK-NEXT:    moore.mir.pcassign %pcassign, %0 : !moore.int
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+  // CHECK-NEXT:}
+int pcassign;
+initial begin
+  assign pcassign=2;
+end
+endmodule

--- a/test/Conversion/ImportVerilog/test.sv
+++ b/test/Conversion/ImportVerilog/test.sv
@@ -4,13 +4,11 @@
 module BinaryOp();
 // CHECK-NEXT: %a = moore.variable : !moore.int
 // CHECK-NEXT: %0 = moore.mir.constant 12 : !moore.int
-// CHECK-NEXT: %1 = moore.conversion %0 : (!moore.int) -> !moore.int
-// CHECK-NEXT: moore.mir.bpassign %a, %1 : !moore.int
+// CHECK-NEXT: moore.mir.bpassign %a, %0 : !moore.int
   int a = 12;
 // CHECK-NEXT: %b = moore.variable : !moore.int
-// CHECK-NEXT: %2 = moore.mir.constant 5 : !moore.int
-// CHECK-NEXT: %3 = moore.conversion %2 : (!moore.int) -> !moore.int
-// CHECK-NEXT: moore.mir.bpassign %b, %3 : !moore.int
+// CHECK-NEXT: %1 = moore.mir.constant 5 : !moore.int
+// CHECK-NEXT: moore.mir.bpassign %b, %1 : !moore.int
   int b = 5;
 // CHECK-NEXT: %log_and = moore.variable : !moore.int
 // CHECK-NEXT: %log_equiv = moore.variable : !moore.int
@@ -39,73 +37,73 @@ module BinaryOp();
   int arith_shl, arith_shr, log_shl, log_shr;
 // CHECK-NEXT: moore.procedure(initial) 
   initial begin
-// CHECK-NEXT:   %4 = moore.mir.logic and %a, %b : !moore.int, !moore.int
-// CHECK-NEXT:   moore.mir.bpassign %log_and, %4 : !moore.int
+// CHECK-NEXT:   %2 = moore.mir.logic and %a, %b : !moore.int, !moore.int
+// CHECK-NEXT:   moore.mir.bpassign %log_and, %2 : !moore.int
     log_and = a && b;
-// CHECK-NEXT:   %5 = moore.mir.logic equiv %a, %b : !moore.int, !moore.int
-// CHECK-NEXT:   moore.mir.bpassign %log_equiv, %5 : !moore.int
+// CHECK-NEXT:   %3 = moore.mir.logic equiv %a, %b : !moore.int, !moore.int
+// CHECK-NEXT:   moore.mir.bpassign %log_equiv, %3 : !moore.int
     log_equiv = a <-> b;
-// CHECK-NEXT:   %6 = moore.mir.logic impl %a, %b : !moore.int, !moore.int
-// CHECK-NEXT:   moore.mir.bpassign %log_impl, %6 : !moore.int
+// CHECK-NEXT:   %4 = moore.mir.logic impl %a, %b : !moore.int, !moore.int
+// CHECK-NEXT:   moore.mir.bpassign %log_impl, %4 : !moore.int
     log_impl = a ->b;
-// CHECK-NEXT:   %7 = moore.mir.logic or %a, %b : !moore.int, !moore.int
-// CHECK-NEXT:   moore.mir.bpassign %log_or, %7 : !moore.int
+// CHECK-NEXT:   %5 = moore.mir.logic or %a, %b : !moore.int, !moore.int
+// CHECK-NEXT:   moore.mir.bpassign %log_or, %5 : !moore.int
     log_or = a || b;
-// CHECK-NEXT:   %8 = moore.mir.binBitwise and %a, %b : !moore.int, !moore.int
-// CHECK-NEXT:   moore.mir.bpassign %bin_bit_and, %8 : !moore.int
+// CHECK-NEXT:   %6 = moore.mir.binBitwise and %a, %b : !moore.int, !moore.int
+// CHECK-NEXT:   moore.mir.bpassign %bin_bit_and, %6 : !moore.int
     bin_bit_and = a & b;
-// CHECK-NEXT:   %9 = moore.mir.binBitwise or %a, %b : !moore.int, !moore.int
-// CHECK-NEXT:   moore.mir.bpassign %bin_bit_or, %9 : !moore.int
+// CHECK-NEXT:   %7 = moore.mir.binBitwise or %a, %b : !moore.int, !moore.int
+// CHECK-NEXT:   moore.mir.bpassign %bin_bit_or, %7 : !moore.int
     bin_bit_or = a | b;
-// CHECK-NEXT:   %10 = moore.mir.binBitwise xor %a, %b : !moore.int, !moore.int
-// CHECK-NEXT:   moore.mir.bpassign %bin_bit_xor, %10 : !moore.int
+// CHECK-NEXT:   %8 = moore.mir.binBitwise xor %a, %b : !moore.int, !moore.int
+// CHECK-NEXT:   moore.mir.bpassign %bin_bit_xor, %8 : !moore.int
     bin_bit_xor = a ^ b;
-// CHECK-NEXT:   %11 = moore.mir.binBitwise xnor %a, %b : !moore.int, !moore.int
-// CHECK-NEXT:   moore.mir.bpassign %bin_bit_xnor, %11 : !moore.int
+// CHECK-NEXT:   %9 = moore.mir.binBitwise xnor %a, %b : !moore.int, !moore.int
+// CHECK-NEXT:   moore.mir.bpassign %bin_bit_xnor, %9 : !moore.int
     bin_bit_xnor = a ~^ b;
-// CHECK-NEXT:   %12 = moore.mir.eq case %a, %b : !moore.int, !moore.int
-// CHECK-NEXT:   %13 = moore.conversion %12 : (i1) -> !moore.int
-// CHECK-NEXT:   moore.mir.bpassign %case_eq, %13 : !moore.int
+// CHECK-NEXT:   %10 = moore.mir.eq case %a, %b : !moore.int, !moore.int
+// CHECK-NEXT:   %11 = moore.conversion %10 : (i1) -> !moore.int
+// CHECK-NEXT:   moore.mir.bpassign %case_eq, %11 : !moore.int
     case_eq = a === b;
-// CHECK-NEXT:   %14 = moore.mir.ne case %a, %b : !moore.int, !moore.int
-// CHECK-NEXT:   %15 = moore.conversion %14 : (i1) -> !moore.int
-// CHECK-NEXT:   moore.mir.bpassign %case_neq, %15 : !moore.int
+// CHECK-NEXT:   %12 = moore.mir.ne case %a, %b : !moore.int, !moore.int
+// CHECK-NEXT:   %13 = moore.conversion %12 : (i1) -> !moore.int
+// CHECK-NEXT:   moore.mir.bpassign %case_neq, %13 : !moore.int
     case_neq = a !== b;
-// CHECK-NEXT:   %16 = moore.mir.eq %a, %b : !moore.int, !moore.int
-// CHECK-NEXT:   %17 = moore.conversion %16 : (i1) -> !moore.int
-// CHECK-NEXT:   moore.mir.bpassign %log_eq, %17 : !moore.int
+// CHECK-NEXT:   %14 = moore.mir.eq %a, %b : !moore.int, !moore.int
+// CHECK-NEXT:   %15 = moore.conversion %14 : (i1) -> !moore.int
+// CHECK-NEXT:   moore.mir.bpassign %log_eq, %15 : !moore.int
     log_eq = a == b;
-// CHECK-NEXT:   %18 = moore.mir.ne %a, %b : !moore.int, !moore.int
-// CHECK-NEXT:   %19 = moore.conversion %18 : (i1) -> !moore.int
-// CHECK-NEXT:   moore.mir.bpassign %log_neq, %19 : !moore.int
+// CHECK-NEXT:   %16 = moore.mir.ne %a, %b : !moore.int, !moore.int
+// CHECK-NEXT:   %17 = moore.conversion %16 : (i1) -> !moore.int
+// CHECK-NEXT:   moore.mir.bpassign %log_neq, %17 : !moore.int
     log_neq = a != b ;
-// CHECK-NEXT:   %20 = moore.mir.icmp gte %a, %b : !moore.int, !moore.int
-// CHECK-NEXT:   %21 = moore.conversion %20 : (i1) -> !moore.int
-// CHECK-NEXT:   moore.mir.bpassign %gte, %21 : !moore.int
+// CHECK-NEXT:   %18 = moore.mir.icmp gte %a, %b : !moore.int, !moore.int
+// CHECK-NEXT:   %19 = moore.conversion %18 : (i1) -> !moore.int
+// CHECK-NEXT:   moore.mir.bpassign %gte, %19 : !moore.int
     gte = a >= b;
-// CHECK-NEXT:   %22 = moore.mir.icmp gt %a, %b : !moore.int, !moore.int
-// CHECK-NEXT:   %23 = moore.conversion %22 : (i1) -> !moore.int
-// CHECK-NEXT:   moore.mir.bpassign %gt, %23 : !moore.int
+// CHECK-NEXT:   %20 = moore.mir.icmp gt %a, %b : !moore.int, !moore.int
+// CHECK-NEXT:   %21 = moore.conversion %20 : (i1) -> !moore.int
+// CHECK-NEXT:   moore.mir.bpassign %gt, %21 : !moore.int
     gt = a > b;
-// CHECK-NEXT:   %24 = moore.mir.icmp lte %a, %b : !moore.int, !moore.int
-// CHECK-NEXT:   %25 = moore.conversion %24 : (i1) -> !moore.int
-// CHECK-NEXT:   moore.mir.bpassign %lte, %25 : !moore.int
+// CHECK-NEXT:   %22 = moore.mir.icmp lte %a, %b : !moore.int, !moore.int
+// CHECK-NEXT:   %23 = moore.conversion %22 : (i1) -> !moore.int
+// CHECK-NEXT:   moore.mir.bpassign %lte, %23 : !moore.int
     lte = a <= b;
-// CHECK-NEXT:   %26 = moore.mir.icmp lt %a, %b : !moore.int, !moore.int
-// CHECK-NEXT:   %27 = moore.conversion %26 : (i1) -> !moore.int
-// CHECK-NEXT:   moore.mir.bpassign %lt, %27 : !moore.int
+// CHECK-NEXT:   %24 = moore.mir.icmp lt %a, %b : !moore.int, !moore.int
+// CHECK-NEXT:   %25 = moore.conversion %24 : (i1) -> !moore.int
+// CHECK-NEXT:   moore.mir.bpassign %lt, %25 : !moore.int
     lt = a < b;
-// CHECK-NEXT:   %28 = moore.mir.shl arithmetic %a, %b : !moore.int, !moore.int
-// CHECK-NEXT:   moore.mir.bpassign %arith_shl, %28 : !moore.int
+// CHECK-NEXT:   %26 = moore.mir.shl arithmetic %a, %b : !moore.int, !moore.int
+// CHECK-NEXT:   moore.mir.bpassign %arith_shl, %26 : !moore.int
     arith_shl = a <<< b;
-// CHECK-NEXT:   %29 = moore.mir.shr arithmetic %a, %b : !moore.int, !moore.int
-// CHECK-NEXT:   moore.mir.bpassign %arith_shr, %29 : !moore.int
+// CHECK-NEXT:   %27 = moore.mir.shr arithmetic %a, %b : !moore.int, !moore.int
+// CHECK-NEXT:   moore.mir.bpassign %arith_shr, %27 : !moore.int
     arith_shr = a >>> b;
-// CHECK-NEXT:   %30 = moore.mir.shl %a, %b : !moore.int, !moore.int
-// CHECK-NEXT:   moore.mir.bpassign %log_shl, %30 : !moore.int
+// CHECK-NEXT:   %28 = moore.mir.shl %a, %b : !moore.int, !moore.int
+// CHECK-NEXT:   moore.mir.bpassign %log_shl, %28 : !moore.int
     log_shl = a << b;
-// CHECK-NEXT:   %31 = moore.mir.shr %a, %b : !moore.int, !moore.int
-// CHECK-NEXT:   moore.mir.bpassign %log_shr, %31 : !moore.int
+// CHECK-NEXT:   %29 = moore.mir.shr %a, %b : !moore.int, !moore.int
+// CHECK-NEXT:   moore.mir.bpassign %log_shr, %29 : !moore.int
     log_shr = a >> b;
   end
 endmodule


### PR DESCRIPTION
1. Fix `test.sv` to pass FileCheck in the recent merge.

2. Added `pcassign` to manage procedural continuous assignments, correcting the previous erroneous generation of `bpassign`.
3. Added `AddOp` and `MulOp`

4. Currently, only `vardeclOp` generates `!moore.lvalue`. However, assigning values to variables generates three op without the `!moore.lvalue` type, as illustrated below:

```Verilog
int cassign_a;
assign cassign_a = 2;

  // CHECK-NEXT:    %cassign_a = moore.variable : !moore.int
  // CHECK-NEXT:    %0 = moore.mir.constant 2 : !moore.int
  // CHECK-NEXT:    moore.mir.cassign %cassign_a, %0 : !moore.int
```


When variables are used for assignment, the generated variables lack `!moore.lvalue` information. This makes it easier to apply Trait Equality Constraints to the operands and the result, but I'm concerned that it may deviate from the designer's original intention.

